### PR TITLE
Fix anyof keyword in the generated sliced document.

### DIFF
--- a/apislice/CopyReferences.cs
+++ b/apislice/CopyReferences.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 


### PR DESCRIPTION
Updated AnyOfRemover visitor code to take care of several anyof scenarios.
- anyof keyword within allof schema
- anyof within properties of schema
- anyof within items of properties schema